### PR TITLE
Finalizing SFP Components Page's Mobile Changes

### DIFF
--- a/src/app/(dashboard)/(research)/sfp_components/page.module.css
+++ b/src/app/(dashboard)/(research)/sfp_components/page.module.css
@@ -19,8 +19,15 @@
 
 .doughnutChart {
   justify-self: center;
-  height: 200px;
-  width: auto;
+  width: 900px;
+  height: 780px;
+}
+@media only screen and (max-width: 768px) {
+  .doughnutChart {
+    justify-self: start;
+    width: 880px;
+    height: 750px;
+  }
 }
 
 .card1Title {
@@ -74,7 +81,7 @@
 @media only screen and (max-width: 600px) {
   .card1Title {
     grid-row: 200;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: bold;
     margin-top: 1vh;
     margin-bottom: 0vh;
@@ -82,7 +89,7 @@
   }
   .card2Title {
     grid-row: 350;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: bold;
     margin-top: 1vh;
     margin-bottom: 0vh;
@@ -90,7 +97,7 @@
   }
   .card3Title {
     grid-row: 450;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: bold;
     margin-top: 1vh;
     margin-bottom: 0vh;
@@ -98,7 +105,7 @@
   }
   .card4Title {
     grid-row: 550;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: bold;
     margin-top: 1vh;
     margin-bottom: 0vh;
@@ -106,7 +113,7 @@
   }
   .card5Title {
     grid-row: 650;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: bold;
     margin-top: 1vh;
     margin-bottom: 0vh;
@@ -114,7 +121,7 @@
   }
   .card6Title {
     grid-row: 750;
-    font-size: 17px;
+    font-size: 16px;
     font-weight: bold;
     margin-top: 1vh;
     margin-bottom: 0vh;

--- a/src/app/(dashboard)/(research)/sfp_components/page.tsx
+++ b/src/app/(dashboard)/(research)/sfp_components/page.tsx
@@ -333,7 +333,7 @@ const options: any = {
 };
 if (isWindowDefined() && window.innerWidth < 768) {
   options.layout.padding.right = 550;
-  options.plugins.datalabels.font.size = 9;
+  options.plugins.datalabels.font.size = 8.5;
   options.plugins.datalabels.font.weight = "normal";
   options.aspectRatio = 1.8;
 }
@@ -375,10 +375,7 @@ export default function QualitativeData() {
   return (
     <main className={styles.main}>
       <ToTopButton />
-      <div
-        style={{ width: "900px", height: "780px" }}
-        className={styles.doughnutChart}
-      >
+      <div className={styles.doughnutChart}>
         <Doughnut data={doughnutData} options={options} />
       </div>
       <p id="food-literacy" className={styles.card1Title}>


### PR DESCRIPTION
Deployed website still had some mobile alignment / sizing issues persisting in the display of donut chart and some card titles. All issues regarding mobile display now resolved to auto fit to size of screen. Example display shown below:

<img width="373" alt="Screen Shot 2024-03-27 at 11 50 40 AM" src="https://github.com/fknmcapstone/deployment/assets/65524500/3536ea8e-1ccb-4e8c-bfd5-6298147a3892">

<img width="370" alt="Screen Shot 2024-03-27 at 11 50 54 AM" src="https://github.com/fknmcapstone/deployment/assets/65524500/60259666-886c-461e-97e8-4ae121f42b7a">
