### PR TITLE
Resolving map scaling issues for School Food Programs page

### DIFF
--- a/src/app/(dashboard)/school_food_programs/page.tsx
+++ b/src/app/(dashboard)/school_food_programs/page.tsx
@@ -85,7 +85,7 @@ export default function CurrentPrograms() {
         <iframe
           data-cy="chart_frame"
           title="School Food Programs"
-          width="100%"
+          width="90%"
           height="100%"
           src="https://app.powerbi.com/view?r=eyJrIjoiYWI1NzhmYzYtYTQwZS00MjIwLWEyNDgtZTFiNDkzZmIzNTNhIiwidCI6IjU1MjQxYmEwLTBiNjgtNGRkYi05ZjE5LWZmNjQ5MjExZTkyMiJ9"
           frameBorder="0"


### PR DESCRIPTION
Previously title appeared from Power BI visual and scaling was inaccurate for canvas size:

<img width="882" alt="Screen Shot 2024-03-31 at 10 16 02 PM" src="https://github.com/fknmcapstone/deployment/assets/65524500/a23bceaf-9206-49db-a6f1-a17a084b2674">


Updated to remove title and correct sizing:

<img width="789" alt="Screen Shot 2024-03-31 at 10 35 41 PM" src="https://github.com/fknmcapstone/deployment/assets/65524500/99f0d35a-258b-4ac1-a0d2-4f7ceaa281cc">
